### PR TITLE
fix:behavior reconnect after resetting

### DIFF
--- a/M5StackHIDCtrlAltDel.ino
+++ b/M5StackHIDCtrlAltDel.ino
@@ -140,6 +140,9 @@ void DisplayGuide() {
 
 class MyCallbacks : public BLEServerCallbacks {
   void onConnect(BLEServer* pServer){
+    BLE2902* desc;
+    desc = (BLE2902*) input->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
+    desc->setNotifications(true);
     isConnected = true;
     DisplayConnectionText();
   }


### PR DESCRIPTION
it can work although  connected after resetting.
リセット後に再接続したときにキー入力が送れるようになった。
I refered below.
修正内容は下記参照。
https://github.com/asterics/esp32_mouse_keyboard/issues/4